### PR TITLE
Handle existing remote task branches

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ Move-Item .\aicloner.exe C:\tools\aicloner.exe
 ```
 
 - リモートリポジトリから `--from`（デフォルト `main`）を `--single-branch` で clone します。
-- clone 完了後にタスク名（この例では `login-ui`）のブランチを `git checkout -b <task_name>` で自動作成し、直ちに切り替えます。
+- 同名のブランチがリモートに存在する場合はそのブランチを clone し、存在しない場合のみ `--from` から `git checkout -b <task_name>` で新規作成します。
 - 同名ディレクトリが存在する場合はエラーになります。
 
 ## タスク clone 削除 `rm`


### PR DESCRIPTION
## Summary
- `add` 時にリモートに同名ブランチが存在する場合、そのブランチを clone するように変更
- リモートに存在しない場合は従来通り `--from` からローカル新規ブランチを切る
- 振る舞いを検証する統合テストを追加し、README に新挙動を記載

## Testing
- cargo test