### PR TITLE
PR作成時のエラー対策: プロンプトに詳細な手順を追加

### DIFF
--- a/src/start.rs
+++ b/src/start.rs
@@ -148,9 +148,12 @@ fn launch_ai_session(workspace_path: &Path, issue_number: u32, ai_tool: AiTool, 
              - 適切な粒度でcommitすること\n\
              - コミットメッセージは日本語で簡潔に書くこと\n\
              - 疑問点はユーザーに聞くこと\n\
-             - ghコマンドを使って実装後にプルリクエストにすること\n\
-             - プルリクエストには該当issueを紐づけること",
-            issue_number
+             - 実装後にプルリクエストを作成する際は、必ず以下の手順を守ること:\n\
+               1. すべての変更をcommitしてワーキングツリーをクリーンにする（git statusで確認）\n\
+               2. リモートブランチにpushする（git push -u origin ブランチ名）\n\
+               3. gh pr createコマンドを実行してプルリクエストを作成する\n\
+               4. プルリクエストには該当issueを紐づけること（Closes #{}を本文に含める）",
+            issue_number, issue_number
         )
     } else {
         format!(
@@ -160,9 +163,12 @@ fn launch_ai_session(workspace_path: &Path, issue_number: u32, ai_tool: AiTool, 
              - 適切な粒度でcommitすること\n\
              - コミットメッセージは日本語で簡潔に書くこと\n\
              - 疑問点はユーザーに聞くこと\n\
-             - ghコマンドを使って実装後にプルリクエストにすること\n\
-             - プルリクエストには該当issueを紐づけること",
-            issue_number
+             - 実装後にプルリクエストを作成する際は、必ず以下の手順を守ること:\n\
+               1. すべての変更をcommitしてワーキングツリーをクリーンにする（git statusで確認）\n\
+               2. リモートブランチにpushする（git push -u origin ブランチ名）\n\
+               3. gh pr createコマンドを実行してプルリクエストを作成する\n\
+               4. プルリクエストには該当issueを紐づけること（Closes #{}を本文に含める）",
+            issue_number, issue_number
         )
     };
 


### PR DESCRIPTION
## 概要
Issue #12で報告されていた「未コミットの変更」「リモートブランチへのpush未実施」によるPR作成エラーを防ぐため、AIへの指示プロンプトを改善しました。

## 変更内容
`src/start.rs` のプロンプト生成部分に、PR作成時の詳細な手順を追加：

1. すべての変更をcommitしてワーキングツリーをクリーンにする（git statusで確認）
2. リモートブランチにpushする（git push -u origin ブランチ名）
3. gh pr createコマンドを実行してプルリクエストを作成する
4. プルリクエストには該当issueを紐づけること（Closes #番号を本文に含める）

## 期待される効果
- AIがPR作成前に必要な準備（commit、push）を確実に実行するようになる
- `--head` フラグを毎回手動で指定する必要がなくなる
- PR作成時のエラー発生率が減少する

## テスト
- ビルドが成功することを確認済み（cargo build）
- プロンプトの構文が正しいことを確認済み

Closes #12

🤖 Generated with [Claude Code](https://claude.com/claude-code)